### PR TITLE
feat: house cleaning

### DIFF
--- a/bin/cli.cjs
+++ b/bin/cli.cjs
@@ -6,10 +6,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const { execSync } = require("node:child_process");
 
-program
-  .name("rise-api")
-  .description("API client generation CLI tool")
-  .version(version);
+program.name("rise-api").description("API client generation CLI tool").version(version);
 
 program
   .command("generate <swaggerFile>")
@@ -21,20 +18,12 @@ program
     try {
       fs.mkdirSync(SRC_DIR, { recursive: true });
 
-      execSync(
-        `npx typed-openapi@0.8.0 "${swaggerFile}" -o "${OUTPUT_FILE}" -r typebox`,
-        { stdio: "inherit" }
-      );
+      execSync(`npx typed-openapi@1.5.0 "${swaggerFile}" -o "${OUTPUT_FILE}" -r typebox`, { stdio: "inherit" });
 
       console.log("Compiling TypeScript to JavaScript...");
-      execSync(
-        `npx tsc --project "${path.join(
-          SRC_DIR,
-          "..",
-          "tsconfig.build.json"
-        )}"`,
-        { stdio: "inherit" }
-      );
+      execSync(`npx tsc --noCheck --project "${path.join(SRC_DIR, "..", "tsconfig.build.json")}"`, {
+        stdio: "inherit",
+      });
 
       fs.rmSync(SRC_DIR, { recursive: true, force: true });
 

--- a/bin/cli.cjs
+++ b/bin/cli.cjs
@@ -6,7 +6,10 @@ const fs = require("node:fs");
 const path = require("node:path");
 const { execSync } = require("node:child_process");
 
-program.name("rise-api").description("API client generation CLI tool").version(version);
+program
+  .name("rise-api")
+  .description("API client generation CLI tool")
+  .version(version);
 
 program
   .command("generate <swaggerFile>")
@@ -18,12 +21,22 @@ program
     try {
       fs.mkdirSync(SRC_DIR, { recursive: true });
 
-      execSync(`npx typed-openapi@1.5.0 "${swaggerFile}" -o "${OUTPUT_FILE}" -r typebox`, { stdio: "inherit" });
+      execSync(
+        `npx typed-openapi@1.5.0 "${swaggerFile}" -o "${OUTPUT_FILE}" -r typebox`,
+        { stdio: "inherit" }
+      );
 
       console.log("Compiling TypeScript to JavaScript...");
-      execSync(`npx tsc --noCheck --project "${path.join(SRC_DIR, "..", "tsconfig.build.json")}"`, {
-        stdio: "inherit",
-      });
+      execSync(
+        `npx tsc --noCheck --project "${path.join(
+          SRC_DIR,
+          "..",
+          "tsconfig.build.json"
+        )}"`,
+        {
+          stdio: "inherit",
+        }
+      );
 
       fs.rmSync(SRC_DIR, { recursive: true, force: true });
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@tanstack/react-query": "^5.8.4",
         "commander": "^13.1.0",
         "typed-openapi": "^0.8.0",
-        "typescript": "^5.5.3",
+        "typescript": "^5.8.3",
       },
       "peerDependencies": {
         "@sinclair/typebox": ">=0.33.4",

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
       "name": "@risemaxi/api-client",
       "devDependencies": {
         "@sinclair/typebox": "^0.33.4",
-        "@tanstack/react-query": "5.8.4",
+        "@tanstack/react-query": "^5.8.4",
         "commander": "^13.1.0",
         "typed-openapi": "^0.8.0",
         "typescript": "^5.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@risemaxi/api-client",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Client Library for Rise",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "prepare": "npm run build",
-    "build": "tsc",
+    "build": "tsc --noCheck",
     "cli": "./bin/cli.cjs"
   },
   "peerDependencies": {
@@ -34,9 +34,9 @@
   },
   "devDependencies": {
     "@sinclair/typebox": "^0.33.4",
-    "commander": "^13.1.0",
     "@tanstack/react-query": "^5.8.4",
+    "commander": "^13.1.0",
     "typed-openapi": "^0.8.0",
-    "typescript": "^5.5.3"
+    "typescript": "^5.8.3"
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -49,7 +49,10 @@ export class RiseApiClient {
     return this.#enabledParsing ? Value.Parse(schema, value) : value;
   }
 
-  #parseAsync<T extends TSchema>(schema: T, value: Promise<unknown>): Promise<StaticDecode<T, []>> {
+  #parseAsync<T extends TSchema>(
+    schema: T,
+    value: Promise<unknown>
+  ): Promise<StaticDecode<T, []>> {
     return value.then((res) => this.#parse(schema, res));
   }
 
@@ -77,7 +80,11 @@ export class RiseApiClient {
 
     return this.#parseAsync(
       EndpointSchema.response,
-      this.fetcher(method, this.#baseUrl + finalPath, this.#parse(EndpointSchema.parameters as TAny, parameters))
+      this.fetcher(
+        method,
+        this.#baseUrl + finalPath,
+        this.#parse(EndpointSchema.parameters as TAny, parameters)
+      )
     );
   }
 
@@ -95,14 +102,20 @@ export class RiseApiClient {
     return this.#request("post", path, ...params);
   }
 
-  patch<Path extends keyof PatchEndpoints, TEndpoint extends PatchEndpoints[Path]>(
+  patch<
+    Path extends keyof PatchEndpoints,
+    TEndpoint extends PatchEndpoints[Path]
+  >(
     path: Path,
     ...params: MaybeOptionalArg<Static<TEndpoint>["parameters"]>
   ): Promise<Static<TEndpoint>["response"]> {
     return this.#request("patch", path, ...params);
   }
 
-  delete<Path extends keyof DeleteEndpoints, TEndpoint extends DeleteEndpoints[Path]>(
+  delete<
+    Path extends keyof DeleteEndpoints,
+    TEndpoint extends DeleteEndpoints[Path]
+  >(
     path: Path,
     ...params: MaybeOptionalArg<Static<TEndpoint>["parameters"]>
   ): Promise<Static<TEndpoint>["response"]> {
@@ -159,7 +172,11 @@ export class RiseApiHooks {
     >
   ): void {
     const [data, ...params] = options;
-    const queryKey = this.getCacheKey(method, path as any, ...(params as never));
+    const queryKey = this.getCacheKey(
+      method,
+      path as any,
+      ...(params as never)
+    );
 
     queryClient.setQueryData(queryKey, data);
   }
@@ -219,10 +236,16 @@ export class RiseApiHooks {
     return this.getCachedData(queryClient, method, path as any, ...params);
   }
 
-  prefetchData<Path extends keyof GetEndpoints, TEndpoint extends GetEndpoints[Path]>(
+  prefetchData<
+    Path extends keyof GetEndpoints,
+    TEndpoint extends GetEndpoints[Path]
+  >(
     queryClient: QueryClient,
     path: Path,
-    ...rest: MaybeOptionalOptions<Static<TEndpoint>["parameters"], FetchQueryOptions>
+    ...rest: MaybeOptionalOptions<
+      Static<TEndpoint>["parameters"],
+      FetchQueryOptions
+    >
   ) {
     const [config, options] = rest;
     const queryKey = this.getCacheKey("get", path, config as never);
@@ -235,9 +258,15 @@ export class RiseApiHooks {
     });
   }
 
-  usePrefetchData<Path extends keyof GetEndpoints, TEndpoint extends GetEndpoints[Path]>(
+  usePrefetchData<
+    Path extends keyof GetEndpoints,
+    TEndpoint extends GetEndpoints[Path]
+  >(
     path: Path,
-    ...rest: MaybeOptionalOptions<Static<TEndpoint>["parameters"], FetchQueryOptions>
+    ...rest: MaybeOptionalOptions<
+      Static<TEndpoint>["parameters"],
+      FetchQueryOptions
+    >
   ) {
     const queryClient = useQueryClient();
 
@@ -286,8 +315,13 @@ export class RiseApiHooks {
     TError = Error
   >(
     path: Path,
-    configMapper: (context: QueryFunctionContext<QueryKey>) => Static<TEndpoint>["parameters"],
-    options: Omit<UseInfiniteQueryOptions<TData, TError>, "queryKey" | "queryFn">
+    configMapper: (
+      context: QueryFunctionContext<QueryKey>
+    ) => Static<TEndpoint>["parameters"],
+    options: Omit<
+      UseInfiniteQueryOptions<TData, TError>,
+      "queryKey" | "queryFn"
+    >
   ): UseInfiniteQueryResult<InfiniteData<TData>, TError> & {
     invalidate: () => Promise<void>;
     queryKey: QueryKey;
@@ -330,7 +364,10 @@ export class RiseApiHooks {
     TError = unknown
   >(
     path: Path,
-    options?: Omit<UseMutationOptions<TData, TError, TVariables>, "mutationKey" | "mutationFn">
+    options?: Omit<
+      UseMutationOptions<TData, TError, TVariables>,
+      "mutationKey" | "mutationFn"
+    >
   ): UseMutationResult<TData, TError, TVariables> & {
     mutationKey: MutationKey;
   } {
@@ -338,7 +375,8 @@ export class RiseApiHooks {
 
     return Object.assign(
       useMutation({
-        mutationFn: (params: Static<TEndpoint>["parameters"]) => this.#client.post(path, params as never),
+        mutationFn: (params: Static<TEndpoint>["parameters"]) =>
+          this.#client.post(path, params as never),
         mutationKey,
         ...(options as {}),
       }),
@@ -354,7 +392,10 @@ export class RiseApiHooks {
     TError = unknown
   >(
     path: Path,
-    options?: Omit<UseMutationOptions<TData, TError, TVariables>, "mutationKey" | "mutationFn">
+    options?: Omit<
+      UseMutationOptions<TData, TError, TVariables>,
+      "mutationKey" | "mutationFn"
+    >
   ): UseMutationResult<TData, TError, TVariables> & {
     mutationKey: MutationKey;
   } {
@@ -362,7 +403,8 @@ export class RiseApiHooks {
 
     return Object.assign(
       useMutation({
-        mutationFn: (params: TVariables) => this.#client.patch(path, params as never),
+        mutationFn: (params: TVariables) =>
+          this.#client.patch(path, params as never),
         mutationKey,
         ...(options as {}),
       }),
@@ -378,7 +420,10 @@ export class RiseApiHooks {
     TError = unknown
   >(
     path: Path,
-    options?: Omit<UseMutationOptions<TData, TError, TVariables>, "mutationKey" | "mutationFn">
+    options?: Omit<
+      UseMutationOptions<TData, TError, TVariables>,
+      "mutationKey" | "mutationFn"
+    >
   ): UseMutationResult<TData, TError, TVariables> & {
     mutationKey: MutationKey;
   } {
@@ -386,7 +431,8 @@ export class RiseApiHooks {
 
     return Object.assign(
       useMutation({
-        mutationFn: (params: TVariables) => this.#client.delete(path, params as never),
+        mutationFn: (params: TVariables) =>
+          this.#client.delete(path, params as never),
         mutationKey,
         ...(options as {}),
       }),
@@ -402,7 +448,10 @@ export class RiseApiHooks {
     TError = unknown
   >(
     path: Path,
-    options?: Omit<UseMutationOptions<TData, TError, TVariables>, "mutationKey" | "mutationFn">
+    options?: Omit<
+      UseMutationOptions<TData, TError, TVariables>,
+      "mutationKey" | "mutationFn"
+    >
   ): UseMutationResult<TData, TError, TVariables> & {
     mutationKey: MutationKey;
   } {
@@ -410,7 +459,8 @@ export class RiseApiHooks {
 
     return Object.assign(
       useMutation({
-        mutationFn: (params: TVariables) => this.#client.put(path, params as never),
+        mutationFn: (params: TVariables) =>
+          this.#client.put(path, params as never),
         mutationKey,
         ...(options as {}),
       }),

--- a/src/client.ts
+++ b/src/client.ts
@@ -7,19 +7,25 @@ import {
   QueryClient,
   QueryFunctionContext,
   QueryKey,
-  useInfiniteQuery,
   UseInfiniteQueryOptions,
   UseInfiniteQueryResult,
-  useMutation,
   UseMutationOptions,
   UseMutationResult,
-  useQuery,
-  useQueryClient,
   UseQueryOptions,
   UseQueryResult,
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
 } from "@tanstack/react-query";
 
-import type { EndpointMethodMap, Fetcher, HttpMethod, MaybeOptionalArg, MaybeOptionalOptions } from "./client.types.js";
+import type {
+  EndpointMethodMap,
+  Fetcher,
+  HttpMethod,
+  MaybeOptionalArg,
+  MaybeOptionalOptions,
+} from "./client.types.js";
 import {
   DeleteEndpoints,
   EndpointByMethod,
@@ -49,7 +55,10 @@ export class RiseApiClient {
     return this.#enabledParsing ? Value.Parse(schema, value) : value;
   }
 
-  #parseAsync<T extends TSchema>(schema: T, value: Promise<unknown>): Promise<StaticDecode<T, []>> {
+  #parseAsync<T extends TSchema>(
+    schema: T,
+    value: Promise<unknown>
+  ): Promise<StaticDecode<T, []>> {
     return value.then((res) => this.#parse(schema, res));
   }
 
@@ -77,7 +86,11 @@ export class RiseApiClient {
 
     return this.#parseAsync(
       EndpointSchema.response,
-      this.fetcher(method, this.#baseUrl + finalPath, this.#parse(EndpointSchema.parameters as TAny, parameters))
+      this.fetcher(
+        method,
+        this.#baseUrl + finalPath,
+        this.#parse(EndpointSchema.parameters as TAny, parameters)
+      )
     );
   }
 
@@ -95,14 +108,20 @@ export class RiseApiClient {
     return this.#request("post", path, ...params);
   }
 
-  patch<Path extends keyof PatchEndpoints, TEndpoint extends PatchEndpoints[Path]>(
+  patch<
+    Path extends keyof PatchEndpoints,
+    TEndpoint extends PatchEndpoints[Path]
+  >(
     path: Path,
     ...params: MaybeOptionalArg<Static<TEndpoint>["parameters"]>
   ): Promise<Static<TEndpoint>["response"]> {
     return this.#request("patch", path, ...params);
   }
 
-  delete<Path extends keyof DeleteEndpoints, TEndpoint extends DeleteEndpoints[Path]>(
+  delete<
+    Path extends keyof DeleteEndpoints,
+    TEndpoint extends DeleteEndpoints[Path]
+  >(
     path: Path,
     ...params: MaybeOptionalArg<Static<TEndpoint>["parameters"]>
   ): Promise<Static<TEndpoint>["response"]> {
@@ -150,7 +169,10 @@ export class RiseApiHooks {
     queryClient: QueryClient,
     method: Method,
     path: Path,
-    ...options: MaybeOptionalOptions<Static<TEndpoint>["response"], Static<TEndpoint>["parameters"]>
+    ...options: MaybeOptionalOptions<
+      Static<TEndpoint>["response"],
+      Static<TEndpoint>["parameters"]
+    >
   ): void {
     const [data, ...params] = options;
     const queryKey = this.getCacheKey(
@@ -171,7 +193,10 @@ export class RiseApiHooks {
   >(
     method: Method,
     path: Path,
-    ...options: MaybeOptionalOptions<Static<TEndpoint>["response"], Static<TEndpoint>["parameters"]>
+    ...options: MaybeOptionalOptions<
+      Static<TEndpoint>["response"],
+      Static<TEndpoint>["parameters"]
+    >
   ): void {
     const queryClient = useQueryClient();
 
@@ -209,10 +234,16 @@ export class RiseApiHooks {
     return this.getCachedData(queryClient, method, path as any, ...params);
   }
 
-  prefetchData<Path extends keyof GetEndpoints, TEndpoint extends GetEndpoints[Path]>(
+  prefetchData<
+    Path extends keyof GetEndpoints,
+    TEndpoint extends GetEndpoints[Path]
+  >(
     queryClient: QueryClient,
     path: Path,
-    ...rest: MaybeOptionalOptions<Static<TEndpoint>["parameters"], FetchQueryOptions>
+    ...rest: MaybeOptionalOptions<
+      Static<TEndpoint>["parameters"],
+      FetchQueryOptions
+    >
   ) {
     const [config, options] = rest;
     const queryKey = this.getCacheKey("get", path, config as never);
@@ -225,9 +256,15 @@ export class RiseApiHooks {
     });
   }
 
-  usePrefetchData<Path extends keyof GetEndpoints, TEndpoint extends GetEndpoints[Path]>(
+  usePrefetchData<
+    Path extends keyof GetEndpoints,
+    TEndpoint extends GetEndpoints[Path]
+  >(
     path: Path,
-    ...rest: MaybeOptionalOptions<Static<TEndpoint>["parameters"], FetchQueryOptions>
+    ...rest: MaybeOptionalOptions<
+      Static<TEndpoint>["parameters"],
+      FetchQueryOptions
+    >
   ) {
     const queryClient = useQueryClient();
 
@@ -276,8 +313,13 @@ export class RiseApiHooks {
     TError = unknown
   >(
     path: Path,
-    configMapper: (context: QueryFunctionContext<QueryKey>) => Static<TEndpoint>["parameters"],
-    options: Omit<UseInfiniteQueryOptions<TData, TError>, "queryKey" | "queryFn">
+    configMapper: (
+      context: QueryFunctionContext<QueryKey>
+    ) => Static<TEndpoint>["parameters"],
+    options: Omit<
+      UseInfiniteQueryOptions<TData, TError>,
+      "queryKey" | "queryFn"
+    >
   ): UseInfiniteQueryResult<InfiniteData<TData>, TError> & {
     invalidate: () => Promise<void>;
     queryKey: QueryKey;
@@ -321,7 +363,10 @@ export class RiseApiHooks {
     TError = unknown
   >(
     path: Path,
-    options?: Omit<UseMutationOptions<TData, TError, TVariables>, "mutationKey" | "mutationFn">
+    options?: Omit<
+      UseMutationOptions<TData, TError, TVariables>,
+      "mutationKey" | "mutationFn"
+    >
   ): UseMutationResult<TData, TError, TVariables> & {
     mutationKey: MutationKey;
   } {
@@ -329,7 +374,8 @@ export class RiseApiHooks {
 
     return Object.assign(
       useMutation({
-        mutationFn: (params: Static<TEndpoint>["parameters"]) => this.#client.post(path, params as never),
+        mutationFn: (params: Static<TEndpoint>["parameters"]) =>
+          this.#client.post(path, params as never),
         mutationKey,
         ...options,
       }),
@@ -345,7 +391,10 @@ export class RiseApiHooks {
     TError = unknown
   >(
     path: Path,
-    options?: Omit<UseMutationOptions<TData, TError, TVariables>, "mutationKey" | "mutationFn">
+    options?: Omit<
+      UseMutationOptions<TData, TError, TVariables>,
+      "mutationKey" | "mutationFn"
+    >
   ): UseMutationResult<TData, TError, TVariables> & {
     mutationKey: MutationKey;
   } {
@@ -369,7 +418,10 @@ export class RiseApiHooks {
     TError = unknown
   >(
     path: Path,
-    options?: Omit<UseMutationOptions<TData, TError, TVariables>, "mutationKey" | "mutationFn">
+    options?: Omit<
+      UseMutationOptions<TData, TError, TVariables>,
+      "mutationKey" | "mutationFn"
+    >
   ): UseMutationResult<TData, TError, TVariables> & {
     mutationKey: MutationKey;
   } {
@@ -393,7 +445,10 @@ export class RiseApiHooks {
     TError = unknown
   >(
     path: Path,
-    options?: Omit<UseMutationOptions<TData, TError, TVariables>, "mutationKey" | "mutationFn">
+    options?: Omit<
+      UseMutationOptions<TData, TError, TVariables>,
+      "mutationKey" | "mutationFn"
+    >
   ): UseMutationResult<TData, TError, TVariables> & {
     mutationKey: MutationKey;
   } {

--- a/src/client.types.ts
+++ b/src/client.types.ts
@@ -7,7 +7,7 @@ import type {
   PatchEndpoints,
   PostEndpoints,
   PutEndpoints,
-} from "./contract.ts";
+} from "./contract.js";
 
 export type HttpMethod = "post" | "get" | "patch" | "delete" | "put";
 export type Fetcher = (
@@ -20,9 +20,7 @@ export type RequiredKeys<T> = {
   [P in keyof T]-?: undefined extends T[P] ? never : P;
 }[keyof T];
 
-export type MaybeOptionalArg<T> = RequiredKeys<T> extends never
-  ? [config?: T]
-  : [config: T];
+export type MaybeOptionalArg<T> = RequiredKeys<T> extends never ? [config?: T] : [config: T];
 
 export type MaybeOptionalOptions<T, O> = RequiredKeys<T> extends never
   ? [config?: T, options?: O]

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "strict": true,
     "outDir": "./dist",
-    "allowJs": true,
-    "checkJs": true,
+    "moduleDetection": "force",
+    "allowJs": false,
     "module": "NodeNext",
     "target": "esnext",
     "moduleResolution": "NodeNext",
@@ -14,5 +14,7 @@
     "declaration": true,
     "declarationMap": true
   },
-  "include": ["src/**/*"]
+  "include": [
+    "src/**/*"
+  ]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -14,7 +14,5 @@
     "declaration": true,
     "declarationMap": true
   },
-  "include": [
-    "src/**/*"
-  ]
+  "include": ["src/**/*"]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,15 +5,16 @@
     "allowJs": true,
     "checkJs": true,
     "module": "NodeNext",
-    "target": "ES2020",
+    "target": "esnext",
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,
     "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true
+    "declarationMap": true
   },
-  "include": ["src/**/*"]
+  "include": [
+    "src/**/*"
+  ]
 }


### PR DESCRIPTION
This PR does a bunch of things.

1. Bumps the typed-api generator. This fixes some of the limitations in its contract generation since the last version we use.

2. Remove source map. Source maps are counter-productive if the source, is not included in the bundle.

3. Remove rest pattern in Tanstack query. Because it undoes their internal optimizations https://tanstack.com/query/latest/docs/eslint/no-rest-destructuring

4. Some Typescipt changes.