### PR TITLE
fix: ts serialization crash

### DIFF
--- a/bin/cli.cjs
+++ b/bin/cli.cjs
@@ -26,6 +26,17 @@ program
         { stdio: "inherit" }
       );
 
+      // Avoid TS7056 by preventing a huge inferred literal type here.
+      const contractSource = fs.readFileSync(OUTPUT_FILE, "utf8");
+      const endpointByMethodPattern = /export const EndpointByMethod\s*=\s*{/;
+      if (endpointByMethodPattern.test(contractSource)) {
+        const patchedSource = contractSource.replace(
+          endpointByMethodPattern,
+          "export const EndpointByMethod: Record<string, Record<string, Endpoint>> = {"
+        );
+        fs.writeFileSync(OUTPUT_FILE, patchedSource, "utf8");
+      }
+
       console.log("Compiling TypeScript to JavaScript...");
       execSync(
         `npx tsc --noCheck --project "${path.join(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@risemaxi/api-client",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Client Library for Rise",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
ISSUE :  for export const EndpointByMethod  TS inferred a massive literal type which it's not able to serialize , it hit it's limit and started throwing 

```
node_modules/@risemaxi/api-client/src/contract.ts:8503:14 - error TS7056: The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed.

8503 export const EndpointByMethod = {
                  ~~~~~~~~~~~~~~~~


Found 1 error in node_modules/@risemaxi/api-client/src/contract.ts:8503
```

SOLUTION IN PR : annotate that line so typescript does not have to infer and then serialize all the literal types